### PR TITLE
Add forgot password link to login

### DIFF
--- a/src/app/auth/login/forms/loginForm/LoginForm.form.tsx
+++ b/src/app/auth/login/forms/loginForm/LoginForm.form.tsx
@@ -57,9 +57,6 @@ export default function LoginForm() {
           <input type={'password'} id="password" placeholder="••••••••" {...register('password', { required: 'Password is required' })} />
         </div>
         {errors.password && <span className={styles.error}>{errors.password.message}</span>}
-        <a href="/auth/forgot-password" className={styles.forgotPassword}>
-          Forgot password?
-        </a>
       </div>
 
       <button type="submit" className={styles.submitButton}>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,7 +1,8 @@
 // app/auth/login/page.tsx
 import AuthModal from '@/layout/authModal/AuthModal.layout';
-import { Metadata } from 'next'; 
+import { Metadata } from 'next';
 import LoginForm from './forms/loginForm/LoginForm.form';
+import styles from './forms/loginForm/LoginForm.module.scss'
 
 export const metadata: Metadata = {
   title: 'Login | Free Agent Portal',
@@ -36,12 +37,18 @@ export default function LoginPage() {
       title="Welcome Back"
       subtitle="Enter your credentials to continue"
       footer={
-        <p>
-          Don't have an account?{' '}
-          <a href="/auth/register">Register →</a>
-        </p>
+        <>
+          <p>
+            Don't have an account? <a href="/auth/register">Register →</a>
+          </p>
+          <p>
+            <a href="/auth/forgot-password" className={styles.forgotPassword}>
+              Forgot password?
+            </a>
+          </p>
+        </>
       }
-    > 
+    >
       <LoginForm />
     </AuthModal>
   );


### PR DESCRIPTION
## Summary
- add forgot password link on the login form
- style the new link

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68419bd0725c8320bcaf32dc9250f03a