### PR TITLE
Add forgot password view

### DIFF
--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -1,0 +1,33 @@
+import { Metadata } from 'next';
+import ForgotPasswordView from '@/views/forgotPassword/ForgotPassword.view';
+
+export const metadata: Metadata = {
+  title: 'Forgot Password | Free Agent Portal',
+  description: 'Reset your Free Agent Portal password.',
+  robots: 'noindex, nofollow',
+  openGraph: {
+    title: 'Forgot Password | Free Agent Portal',
+    description: 'Reset your Free Agent Portal password.',
+    url: 'https://freeagentportal.com/auth/forgot-password',
+    siteName: 'Free Agent Portal',
+    images: [
+      {
+        url: '/images/og-default.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'Free Agent Portal Forgot Password',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Forgot Password | Free Agent Portal',
+    description: 'Reset your Free Agent Portal password.',
+    images: ['/images/og-default.jpg'],
+  },
+};
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordView />;
+}

--- a/src/views/forgotPassword/ForgotPassword.module.scss
+++ b/src/views/forgotPassword/ForgotPassword.module.scss
@@ -1,0 +1,18 @@
+@import '@/styles/globals.scss';
+
+.form {
+  padding: 1rem 0;
+}
+
+.sentMessage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  text-align: center;
+
+  p {
+    font-size: 0.95rem;
+  }
+}

--- a/src/views/forgotPassword/ForgotPassword.view.tsx
+++ b/src/views/forgotPassword/ForgotPassword.view.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import AuthModal from '@/layout/authModal/AuthModal.layout';
+import useApiHook from '@/hooks/useApi';
+import formStyles from '@/styles/Form.module.scss';
+import styles from './ForgotPassword.module.scss';
+
+interface ForgotPasswordData {
+  email: string;
+}
+
+export default function ForgotPasswordView() {
+  const [sent, setSent] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordData>();
+
+  const { mutate: requestReset } = useApiHook({
+    method: 'POST',
+    key: 'forgotPassword',
+    successMessage: 'If that email exists, we\'ve sent a reset link.',
+  }) as any;
+
+  const onSubmit = (data: ForgotPasswordData) => {
+    requestReset(
+      { url: '/auth/forgot-password', formData: data },
+      { onSuccess: () => setSent(true) }
+    );
+  };
+
+  return (
+    <AuthModal title="Forgot Password" showBackButton>
+      {sent ? (
+        <div className={styles.sentMessage}>
+          <p>Check your email for a link to reset your password.</p>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit(onSubmit)} className={`${formStyles.form} ${styles.form}`}>
+          <div className={formStyles.field}>
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              {...register('email', { required: 'Email is required' })}
+            />
+            {errors.email && (
+              <span className={formStyles.error}>{errors.email.message}</span>
+            )}
+          </div>
+          <button type="submit" className={formStyles.submit}>
+            Send Reset Link
+          </button>
+        </form>
+      )}
+    </AuthModal>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/auth/forgot-password` page
- add `ForgotPasswordView` client component
- style forgot password screen

## Testing
- `npm run lint` *(fails: several eslint errors across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68419c626d808320b3c18e6fb94bfc2c