### PR TITLE
Add zustand user store and login redirect

### DIFF
--- a/src/app/auth/login/forms/loginForm/LoginForm.form.tsx
+++ b/src/app/auth/login/forms/loginForm/LoginForm.form.tsx
@@ -2,9 +2,11 @@
 
 import { useForm } from 'react-hook-form';
 import styles from './LoginForm.module.scss';
-import { useState } from 'react';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import useApiHook from '@/hooks/useApi';
 import { useInterfaceStore } from '@/state/interface';
+import { useUserStore } from '@/state/user';
 
 type LoginFormData = {
   email: string;
@@ -18,12 +20,22 @@ export default function LoginForm() {
     formState: { errors },
   } = useForm<LoginFormData>();
 
+  const router = useRouter();
+  const token = useUserStore((state) => state.token);
+  const { setToken } = useUserStore.getState();
+
   const { mutate: login } = useApiHook({
     method: 'POST',
     key: 'login',
     successMessage: 'Login successful',
   }) as any;
   const { addAlert } = useInterfaceStore.getState();
+
+  useEffect(() => {
+    if (token) {
+      router.push('/');
+    }
+  }, [token, router]);
 
   const onSubmit = (data: LoginFormData) => {
     login(
@@ -33,6 +45,9 @@ export default function LoginForm() {
       },
       {
         onSuccess: (response: any) => {
+          if (response?.token) {
+            setToken(response.token);
+          }
           console.log('Login successful:', response);
         },
         onError: (error: any) => {

--- a/src/state/user.ts
+++ b/src/state/user.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+import { mountStoreDevtool } from 'simple-zustand-devtools';
+
+interface UserState {
+  token: string | null;
+  setToken: (token: string) => void;
+  clearToken: () => void;
+}
+
+export const useUserStore = create<UserState>((set) => ({
+  token: null,
+  setToken: (token: string) => set({ token }),
+  clearToken: () => set({ token: null }),
+}));
+
+if (process.env.NODE_ENV === 'development') {
+  mountStoreDevtool('UserStore', useUserStore);
+}


### PR DESCRIPTION
## Summary
- add a dedicated `user` zustand store for holding auth tokens
- store token on successful login and redirect to home when token is present

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run build` *(fails: could not fetch Google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6841a3e000f48320b88b923a923bd413