### PR TITLE
Add redirect field to interface store

### DIFF
--- a/src/state/interface.ts
+++ b/src/state/interface.ts
@@ -14,11 +14,17 @@ interface InterfaceState {
   alerts: AlertMessage[];
   addAlert: (alert: AlertMessage) => void;
   removeAlert: (id: string) => void;
+  /**
+   * URL to redirect to after successful authentication
+   */
+  redirect: string | null;
+  setRedirect: (url: string | null) => void;
 }
 
 export const useInterfaceStore = create<InterfaceState>(
   (set: any, get: any) => ({
     alerts: [],
+    redirect: null,
     addAlert: (alert: AlertMessage) => {
       const id = uuidv4();
       set((state: InterfaceState) => ({
@@ -29,6 +35,9 @@ export const useInterfaceStore = create<InterfaceState>(
       set((state: InterfaceState) => ({
         alerts: state.alerts.filter((alert) => alert.id !== id),
       }));
+    },
+    setRedirect: (url: string | null) => {
+      set({ redirect: url });
     },
   })
 );


### PR DESCRIPTION
## Summary
- extend `InterfaceState` to include `redirect` with setter

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841a67a93208320a4e87ee94ed9ad59