### PR TITLE
Add footer to auth layout

### DIFF
--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -4,8 +4,9 @@ import styles from './layout.module.scss';
 import Logo from '@/components/Logo.component';
 import { Metadata } from 'next';
 import Image from 'next/image';
-import ReactQueryProvider from '@/providers/ReactQueryProvider'; 
+import ReactQueryProvider from '@/providers/ReactQueryProvider';
 import AlertCenter from '@/layout/alertCenter/AlertCenter.layout';
+import Footer from '@/layout/footer/Footer.layout';
 
 export const metadata: Metadata = {
   title: 'Authentication | Free Agent Portal',
@@ -52,6 +53,7 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
           <ReactQueryProvider>
             <main className={styles.authModal}>{children}</main>
           </ReactQueryProvider>
+          <Footer />
         </div>
       </div>
     </div>

--- a/src/layout/footer/Footer.layout.tsx
+++ b/src/layout/footer/Footer.layout.tsx
@@ -1,0 +1,23 @@
+'use client';
+import React from 'react';
+import Link from 'next/link';
+import styles from './Footer.module.scss';
+
+const Footer = () => {
+  const year = new Date().getFullYear();
+  return (
+    <footer className={styles.footer}>
+      <nav className={styles.links}>
+        <Link href="https://example.com/terms" target="_blank" rel="noopener noreferrer">
+          Terms &amp; Conditions
+        </Link>
+        <Link href="https://example.com/privacy" target="_blank" rel="noopener noreferrer">
+          Privacy Policy
+        </Link>
+      </nav>
+      <span className={styles.trademark}>Free Agent Portal® {year}</span>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/layout/footer/Footer.module.scss
+++ b/src/layout/footer/Footer.module.scss
@@ -1,0 +1,27 @@
+.footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #ccc;
+}
+
+.links {
+  display: flex;
+  gap: 1rem;
+}
+
+.links a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.links a:hover {
+  text-decoration: underline;
+}
+
+.trademark {
+  font-size: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- create simple footer layout with links to third-party terms and privacy pages
- style the footer
- include the footer component in the `/auth` layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841a6f65dc08320951c27f59212b3a1