### PR TITLE
Add nprogress-based route loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.4",
     "sass": "^1.89.0",
+    "nprogress": "^0.2.0",
     "uuid": "^11.1.0",
     "zustand": "^5.0.5"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import './globals.css'; 
+import './globals.css';
+import RouteProgress from '@/layout/routeProgress/RouteProgress.layout';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -24,7 +25,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable}`}> 
+        <RouteProgress />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/layout/routeProgress/RouteProgress.layout.tsx
+++ b/src/layout/routeProgress/RouteProgress.layout.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect } from 'react';
+import Router from 'next/router';
+import NProgress from 'nprogress';
+import 'nprogress/nprogress.css';
+
+const RouteProgress = () => {
+  useEffect(() => {
+    const handleStart = () => NProgress.start();
+    const handleStop = () => NProgress.done();
+
+    Router.events.on('routeChangeStart', handleStart);
+    Router.events.on('routeChangeComplete', handleStop);
+    Router.events.on('routeChangeError', handleStop);
+
+    return () => {
+      Router.events.off('routeChangeStart', handleStart);
+      Router.events.off('routeChangeComplete', handleStop);
+      Router.events.off('routeChangeError', handleStop);
+    };
+  }, []);
+
+  return null;
+};
+
+export default RouteProgress;


### PR DESCRIPTION
## Summary
- add `nprogress` dependency
- show a progress bar when routes change

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts and cannot resolve `nprogress` without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841d636bc8483208f174641fe912a7b