### PR TITLE
Adjust registration options

### DIFF
--- a/src/views/registration/Registration.module.scss
+++ b/src/views/registration/Registration.module.scss
@@ -56,6 +56,12 @@
   }
 }
 
+.skipBtn {
+  @extend .continueBtn;
+  margin-top: 0.5rem;
+  background: rgba(255, 255, 255, 0.1);
+}
+
 @include mobile {
   .rolesGrid {
     flex-direction: column;

--- a/src/views/registration/RoleSelector.component.tsx
+++ b/src/views/registration/RoleSelector.component.tsx
@@ -3,20 +3,23 @@ import React, { useState } from 'react';
 import styles from './Registration.module.scss';
 import { useRouter } from 'next/navigation';
 
-const rolesList = ['athlete', 'team'];
+const rolesList = ['athlete'];
 const RoleSelector = () => {
-  const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
+  const [selectedRole, setSelectedRole] = useState<string | null>(null);
   const router = useRouter();
 
   const toggleRole = (role: string) => {
-    setSelectedRoles((prev) =>
-      prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role]
-    );
+    setSelectedRole((prev) => (prev === role ? null : role));
   };
 
   const handleContinue = () => {
-    const query = selectedRoles.join(',');
-    router.push(`/auth/register/flow?role=${query}`);
+    if (selectedRole) {
+      router.push(`/auth/register/flow?role=${selectedRole}`);
+    }
+  };
+
+  const handleSkip = () => {
+    router.push('/auth/register/flow');
   };
 
   return (
@@ -30,7 +33,7 @@ const RoleSelector = () => {
           <button
             key={role}
             className={`${styles.roleBtn} ${
-              selectedRoles.includes(role) ? styles.active : ''
+              selectedRole === role ? styles.active : ''
             }`}
             onClick={() => toggleRole(role)}
           >
@@ -42,9 +45,12 @@ const RoleSelector = () => {
       <button
         className={styles.continueBtn}
         onClick={handleContinue}
-        disabled={selectedRoles.length === 0}
+        disabled={!selectedRole}
       >
         Continue →
+      </button>
+      <button className={styles.skipBtn} onClick={handleSkip}>
+        Continue Without a Profile
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- update registration role selector to only show Athlete
- allow users to skip creating a profile
- style skip option button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68750a188fd8832083eb7bce8a3fcda3